### PR TITLE
added ss3.7 compatability

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,3 @@
+<?php
+
+if (!class_exists('SS_Object')) class_alias('Object', 'SS_Object');

--- a/code/Schema.php
+++ b/code/Schema.php
@@ -4,7 +4,7 @@ namespace Broarm\Schema;
 
 use Broarm\Schema\Builder\SchemaBuilder;
 use ClassInfo;
-use Object;
+use SS_Object;
 
 /**
  * Schema.php
@@ -18,7 +18,7 @@ use Object;
  * Date: 03/11/16
  * @deprecated
  */
-class Schema extends Object
+class Schema extends SS_Object
 {
     //private static $logo = 'schema/images/default.png';
 

--- a/code/SchemaBuilders/SchemaBuilder.php
+++ b/code/SchemaBuilders/SchemaBuilder.php
@@ -8,13 +8,13 @@
 
 namespace Broarm\Schema\Builder;
 
-use Object;
+use SS_Object;
 
 
 /**
  * SchemaBuilder
  */
-abstract class SchemaBuilder extends Object {
+abstract class SchemaBuilder extends SS_Object {
 
     /**
      * Get the schema from the given data


### PR DESCRIPTION
ss3.7 can't use the `Object` class as it's being used by php7.2 so i have replaced all references to it with `SS_Object` and added a alias for backwards compatibility support